### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,50 +1,51 @@
 {
-    "Registrations": [
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/TengdaHan/MemDPC",
-                    "commitHash": "d7dbbf0dc6ec4aa8ff9a5dc8c189d78f4e5e34a7"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/SwinTransformer/Transformer-SSL",
-                    "commitHash": "4510de1f21ee6f9810a74494c254081dd8f2c383"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/NVlabs/PWC-Net",
-                    "commitHash": "185b0e2beb45ad029bb66d818812f8dcc2aed9c6"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/castacks/tartanvo",
-                    "commitHash": "de1d3c3b272c9cfb37380f86832f3143ee25f9b5"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/kenshohara/3D-ResNets-PyTorch",
-                    "commitHash": "540a0ea1abaee379fa3651d4d5afbd2d667a1f49"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/TengdaHan/MemDPC",
+          "commitHash": "d7dbbf0dc6ec4aa8ff9a5dc8c189d78f4e5e34a7"
         }
-    ],
-    "Version": 1
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/SwinTransformer/Transformer-SSL",
+          "commitHash": "4510de1f21ee6f9810a74494c254081dd8f2c383"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/NVlabs/PWC-Net",
+          "commitHash": "185b0e2beb45ad029bb66d818812f8dcc2aed9c6"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/castacks/tartanvo",
+          "commitHash": "de1d3c3b272c9cfb37380f86832f3143ee25f9b5"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/kenshohara/3D-ResNets-PyTorch",
+          "commitHash": "540a0ea1abaee379fa3651d4d5afbd2d667a1f49"
+        }
+      }
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.